### PR TITLE
Small change and bugfix

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -18,15 +18,19 @@ async function fixDownloads(ManifestJSON) {
 
 async function determinOS() {
   let OS = "";
-  if (process.platform === "win32") {
-    
-    OS = "windows";
-  } else if (process.platform === "linux") {
-    OS = "linux";
-  } else if (process.platform === "darwin") {
-    OS = "macos";
-  } else {
-    console.log("Unsupported OS");
+  switch(process.platform) {
+    case "win32":
+      OS = "win32";
+      break;
+    case "linux":
+      OS = "linux";
+      break;
+    case "darwin":
+      OS = "macos";
+      break;
+    default:
+      console.log("Unsupported OS");
   }
+
   return OS;    
 }

--- a/index.js
+++ b/index.js
@@ -135,11 +135,9 @@ let themeChannel = await select({
 if (themeChannel == "1") {
     // remove vanilla-theme from assets object
     delete assets["vanilla-theme"];
-    message: ""
 } else if (themeChannel == "2") {
     // remove fancy-theme from assets object
     delete assets["fancy-theme"];
-    message: ""
 }
 
 let assetPath = downloadPath.toString() + "/.minecraft/labymod-neo/assets/";

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ let releaseChannel = await select({
     message: 'Which release channel do you want to download?',
     // only include snapshot and production
     options: JSON.parse(JSON.stringify(labyVersions)),
-    required: true,
+    required: true
 });
 
 let labyMCVersions = await downloadSpecificMC(releaseChannel);
@@ -91,7 +91,6 @@ function checkIfFileExists(path) {
     }
 }
 
-s.start('Checking if LabyMod-4.jar exists');
 // remove \\ and replace with /
 downloadPath = downloadPath.replace(/\\/g, "/");
 let labyDownloadPath = downloadPath.toString() + "/libraries/";
@@ -104,12 +103,11 @@ if (!fs.existsSync(labyDownloadPath)) {
 if (checkIfFileExists(labyDownloadPath.toString() + "LabyMod-4.jar") == true) {
     // delete file
     const shouldContinue = await confirm({
-        message: 'Do you want to backup the old LabyMod-4.jar?',
+        message: 'Do you want to backup the old LabyMod-4.jar?'
     });
     if (shouldContinue) {
         await fs.renameSync(labyDownloadPath.toString() + "LabyMod-4.jar", labyDownloadPath.toString() + "LabyMod-4.jar.old");
     }
-    s.message('Renamed LabyMod-4.jar to LabyMod-4.jar.old');
 }
 
 s.message('LabyMod-4.jar does not exist');
@@ -131,15 +129,17 @@ let themeChannel = await select({
             label: "vanilla"
         }
     ],
-    required: true,
+    required: true
 });
 
 if (themeChannel == "1") {
     // remove vanilla-theme from assets object
     delete assets["vanilla-theme"];
+    message: ""
 } else if (themeChannel == "2") {
     // remove fancy-theme from assets object
     delete assets["fancy-theme"];
+    message: ""
 }
 
 let assetPath = downloadPath.toString() + "/.minecraft/labymod-neo/assets/";
@@ -179,6 +179,6 @@ for (const asset in assets) {
         }
     }
 }
-s.stop();
+
 
 outro('LabyMod Downloader complete!');


### PR DESCRIPTION
**Changelog:**
- Replaced the if query in `helper.js` for the `determinOS()` function with switch cases
- Fixed double text output in the `index.js` by removing current progress output that would get replaced with the current message.

In the future we can use a different way to add the current progress output as text, so in the future it won't get replaced with the message prior before that.