### PR TITLE
Removed determinOS function

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -15,22 +15,3 @@ async function fixDownloads(ManifestJSON) {
   });
   return ManifestJSON;
 }
-
-async function determinOS() {
-  let OS = "";
-  switch(process.platform) {
-    case "win32":
-      OS = "win32";
-      break;
-    case "linux":
-      OS = "linux";
-      break;
-    case "darwin":
-      OS = "macos";
-      break;
-    default:
-      console.log("Unsupported OS");
-  }
-
-  return OS;    
-}


### PR DESCRIPTION
I removed the determinOS function, as I just noticed that we actually never use this function.
So this can be removed and in the future if we ever need the function, we can add it back and use it.